### PR TITLE
fixed URL of Day 4 of the Spatial Statistics training  (issue #5)

### DIFF
--- a/_posts/2021-01-12-4-day-training-in-spatial-statistics-with-philippe-marchand/4-day-training-in-spatial-statistics-with-philippe-marchand.Rmd
+++ b/_posts/2021-01-12-4-day-training-in-spatial-statistics-with-philippe-marchand/4-day-training-in-spatial-statistics-with-philippe-marchand.Rmd
@@ -39,7 +39,7 @@ The content included three types of spatial statistical analyses and their appli
 |1| &bull; Introduction to spatial statistics <br> &bull; Point pattern analysis<br>| [Spatial Statistics in Ecology, Part 1](https://bios2.github.io/Marchand/2021-01-12-spatial-statistics-in-ecology/) |
 |2| &bull; Spatial correlation <br> &bull; Geoestatistical models | [Spatial Statistics in Ecology, Part 2](https://bios2.github.io/Marchand/2021-01-14-spatial-statistics-in-ecology/) |
 |3| &bull; Areal data <br> &bull; Moran’s I <br> &bull; Spatial autoregression models <br> &bull; Analysis of areal data in R  | [Spatial Statistics in Ecology, Part 3](https://bios2.github.io/Marchand/2021-01-19-spatial-statistics-in-ecology/) |
-|4| &bull; GLMM with spatial Gaussian process <br> &bull; GLMM with spatial autoregression | [Spatial Statistics in Ecology, Part 4](https://bios2.github.io/Marchand/2021-01-21-spatial-statistics-in-ecology/) |
+|4| &bull; GLMM with spatial Gaussian process <br> &bull; GLMM with spatial autoregression | [Spatial Statistics in Ecology, Part 4](https://bios2.github.io/Marchand/2021-01-21-spatial-statistics-in-ecology-part-4/) |
 
 
 

--- a/_posts/2021-01-12-4-day-training-in-spatial-statistics-with-philippe-marchand/4-day-training-in-spatial-statistics-with-philippe-marchand.html
+++ b/_posts/2021-01-12-4-day-training-in-spatial-statistics-with-philippe-marchand/4-day-training-in-spatial-statistics-with-philippe-marchand.html
@@ -1532,7 +1532,7 @@ code span.wa { color: #5e5e5e; font-style: italic; } /* Warning */
 <tr class="even">
 <td>4</td>
 <td style="text-align: left;">• GLMM with spatial Gaussian process <br> • GLMM with spatial autoregression</td>
-<td style="text-align: left;"><a href="https://bios2.github.io/Marchand/2021-01-21-spatial-statistics-in-ecology/">Spatial Statistics in Ecology, Part 4</a></td>
+<td style="text-align: left;"><a href="https://bios2.github.io/Marchand/2021-01-21-spatial-statistics-in-ecology-part-4/">Spatial Statistics in Ecology, Part 4</a></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Fixed URL of Day 4 of the Spatial Statistics training in the .html and .Rmd file of the main page.

Not sure why, but it was the only English URL that has 'part-4' at the end (like the French version and the file names).

(fixes issues #5)